### PR TITLE
hotfixes

### DIFF
--- a/src/pages/Attendance/Components/AttendanceFilter.jsx
+++ b/src/pages/Attendance/Components/AttendanceFilter.jsx
@@ -1,14 +1,14 @@
-import { Select } from "antd";
+import { DatePicker } from "antd";
 
-const AttendanceFilter = ({ selectedFilter, setSelectedFilter, filterOptions, className }) => {
+const AttendanceFilter = ({ selectedFilter, setSelectedFilter, className }) => {
   return (
-    <Select
+    <DatePicker
+      picker="month"
       value={selectedFilter}
-      onChange={setSelectedFilter}
+      onChange={(date) => setSelectedFilter(date)}
       style={{ width: 200, marginBottom: 20 }}
-      options={filterOptions.map(({ label, value }) => ({ label, value }))}
-      variant="filled"
       className={className}
+      format="MMMM YYYY"
     />
   );
 };

--- a/src/pages/Slots/index.jsx
+++ b/src/pages/Slots/index.jsx
@@ -12,9 +12,7 @@ function Slots() {
   const { user } = userStore()
 
   useEffect(() => {
-    if (!slots || slots.length <= 0) {
-      getSlots(0, { sort: { start_date: -1 }, query: { booked_student_id: user._id, course_id: user?.details_id?.course_id?._id || user?.details_id?.course_id }, populate: "center_id session" })
-    }
+    getSlots(0, { sort: { start_date: -1 }, query: { booked_student_id: user._id, course_id: user?.details_id?.course_id?._id || user?.details_id?.course_id }, populate: "center_id session" })
   }, [])
 
   const groupedSlots = useMemo(() => groupByMonthName(slots), [slots])

--- a/src/pages/Students/Component/AllotSessions.jsx
+++ b/src/pages/Students/Component/AllotSessions.jsx
@@ -103,7 +103,7 @@ export const sessionSlotOptionRenderer = (option, user) => {
 
   const { data: session } = option.data;
   if (!session) return null;
-  const { remainingSlots } = session
+  const { remainingSlots, additionalBookings } = session
 
   const weekday = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'][session.weekDay];
   const time = dayjs(session.start_time).format('h:mm A');
@@ -126,7 +126,7 @@ export const sessionSlotOptionRenderer = (option, user) => {
           {time}
         </p>
       </div>
-      <div>
+      <div className='flex gap-2'>
         <Tag
           color={slotColor}
           style={{
@@ -136,6 +136,16 @@ export const sessionSlotOptionRenderer = (option, user) => {
           }}
         >
           {remainingSlots} slot{remainingSlots !== 1 ? 's' : ''} left
+        </Tag>
+        <Tag
+          color='gold'
+          style={{
+            fontWeight: 600,
+            borderRadius: 4,
+            marginRight: 0
+          }}
+        >
+          + {additionalBookings}
         </Tag>
       </div>
     </Flex>

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -3,15 +3,23 @@ import html2canvas from "html2canvas";
 import jsPDF from "jspdf";
 import _ from "lodash";
 import React from "react";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export const formatDate = (date) => {
   if (!date) return "";
   // Add 5 hours 30 minutes to convert to UTC+5:30, then format
-  return dayjs(date).add(330, 'minute').format("D MMM, YYYY");
+  return dayjs(date)
+    .tz("Asia/Kolkata")
+    .format("D MMM, YYYY");
 };
 
 export const formatTime = (time) => {
   if (!time) return ""
+
   return dayjs(time).format("h:mm A")
 };
 


### PR DESCRIPTION
Corrected enquiry created date display
Enquiries created on a specific date (e.g., 4th Jan) are now displayed accurately, eliminating the one-day offset issue.

Enabled visibility of previous year data
Data from earlier years is now correctly fetched and displayed across reports and listings.

Separated normal and additional slot display
Normal slots and additional slots are now shown independently for better clarity.