### PR TITLE
V 2.3.6

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -219,7 +219,13 @@ const MENU_CONFIG = [
     label: "Syllabus Gallery",
     icon: PictureOutlined,
     path: "/admin/syllabus-gallery",
-    roles: [ROLES.ADMIN],
+    roles: [ROLES.ADMIN, ROLES.MANAGER],
+  },
+  {
+    label: "Syllabus Gallery",
+    icon: PictureOutlined,
+    path: "/faculty/syllabus-gallery",
+    roles: [ROLES.FACULTY],
   },
   {
     label: "Courses",

--- a/src/pages/SyllabusGallery/index.jsx
+++ b/src/pages/SyllabusGallery/index.jsx
@@ -12,13 +12,6 @@ function SyllabusGallery() {
     const [searchQuery, setSearchQuery] = useState('')
 
     // Check permission - admin only
-    if (user?.role !== ROLES.ADMIN) {
-        return (
-            <div className="text-center py-8">
-                You don't have permission to access the syllabus gallery
-            </div>
-        )
-    }
 
     return (
         <Title

--- a/src/routes/faculty.jsx
+++ b/src/routes/faculty.jsx
@@ -19,7 +19,7 @@ const Slots = lazy(() => import("@pages/Slots/ManagerSlots"))
 const MyAttendance = lazy(() => import("@pages/FacultyAttendance/MyAttendance"))
 const MyLeaves = lazy(() => import("@pages/FacultyLeaves/MyLeaves"))
 const AddSessionStatus = lazy(() => import("@pages/Students/AddSessionStatus"))
-
+const SyllabusGallery = lazy(() => import("@pages/SyllabusGallery"))
 export const LazyLoader = ({ element }) => {
   const location = useLocation();
   return (<Suspense
@@ -119,6 +119,11 @@ export const facultyRoutes = [
             path: "/faculty/session-status/:studentId",
             element: <LazyLoader element={<AddSessionStatus />} />,
             title: "Add Session Status"
+          },
+          {
+            path: "/faculty/syllabus-gallery",
+            element: <LazyLoader element={<SyllabusGallery />} />,
+            title: "Syllabus Gallery",
           },
         ]
       }


### PR DESCRIPTION
Make the Syllabus Gallery available to faculty and managers. Changes:
- src/components/Sidebar.jsx: include ROLES.MANAGER on the existing admin entry and add a separate menu entry for /faculty/syllabus-gallery with ROLES.FACULTY.
- src/pages/SyllabusGallery/index.jsx: remove the admin-only permission check so non-admin users (e.g., faculty) can view the page.
- src/routes/faculty.jsx: lazy-import the SyllabusGallery and add a faculty route for /faculty/syllabus-gallery.

This enables faculty users to access the gallery via the faculty sidebar and route while keeping admin/manager access for the existing admin path.