### PR TITLE
V 2.3.8

### DIFF
--- a/src/pages/Activities/Components/ActivityList.jsx
+++ b/src/pages/Activities/Components/ActivityList.jsx
@@ -20,7 +20,7 @@ function ActivityList({ activities }) {
           key={index}
         >
           {isImage(activity) ? (
-            <ActivityItem.Image url={activity?.resource?.url} fileName={activity?.resource?.fileName || activity?.title} />
+            <ActivityItem.Image url={activity?.resource?.url} images={activity?.resource?.images} fileName={activity?.resource?.fileName || activity?.title} />
           ) : isDocument(activity) ? (
             <ActivityItem.Document fileName={activity?.resource?.fileName} fileSize={formatFileSize(activity?.resource?.fileSize)} type={activity?.resource?.fileType} url={activity?.resource?.url} />
           ) : (

--- a/src/pages/Students/Component/CustomSyllabusForm.jsx
+++ b/src/pages/Students/Component/CustomSyllabusForm.jsx
@@ -88,12 +88,19 @@ function CustomSyllabusForm({ student, course }) {
                                         }`}
                                     onClick={() => setSelectedImage(image)}
                                     cover={
-                                        <Image
-                                            alt={image.name}
-                                            src={image.url}
-                                            preview={false}
-                                            style={{ width: '100%', height: '160px', objectFit: 'cover' }}
-                                        />
+                                        <div className="relative group/preview inline-block w-full h-[160px]">
+                                            <Image
+                                                alt={image.name}
+                                                src={image.images && image.images.length > 0 ? image.images[0] : image.url}
+                                                preview={false}
+                                                style={{ width: '100%', height: '160px', objectFit: 'cover' }}
+                                            />
+                                            {image.images && image.images.length > 1 && (
+                                                <span className="absolute bottom-2 left-2 bg-black/60 text-white text-[10px] px-1.5 py-0.5 rounded-md pointer-events-none z-10 group-hover/preview:bg-black/80 transition-colors">
+                                                    +{image.images.length - 1} view
+                                                </span>
+                                            )}
+                                        </div>
                                     }
                                 >
                                     <Card.Meta

--- a/src/pages/Students/Component/SessionStatusTable.jsx
+++ b/src/pages/Students/Component/SessionStatusTable.jsx
@@ -76,17 +76,40 @@ function SessionStatusTable({ student }) {
         key: "image",
         render: (imageName) => {
           const image = findImageByName(imageName);
+          const hasMultipleImages = image?.images && image.images.length > 1;
+          const displayUrl = hasMultipleImages ? image.images[0] : (image?.images?.[0] || image?.url);
+
           return (
             <div className="flex items-center gap-2">
-              {image?.url && (
-                <Image
-                  src={image.url}
-                  alt={imageName}
-                  width={50}
-                  height={50}
-                  className="object-cover rounded"
-                  preview={{ src: image.url }}
-                />
+              {displayUrl && (
+                <div className="relative inline-block group/preview cursor-pointer">
+                  {hasMultipleImages ? (
+                    <Image.PreviewGroup>
+                      <Image
+                        src={displayUrl}
+                        alt={imageName}
+                        width={50}
+                        height={50}
+                        className="object-cover rounded hover:opacity-90 transition-opacity"
+                      />
+                      {image.images.slice(1).map((imgUrl, idx) => (
+                        <Image key={idx} src={imgUrl} style={{ display: 'none' }} preview={{ src: imgUrl }} />
+                      ))}
+                      <span className="absolute bottom-0 right-0 bg-black/60 text-white text-[8px] px-1 py-0.5 rounded-tl pointer-events-none group-hover/preview:bg-black/80 transition-colors leading-none">
+                        +{image.images.length - 1} view
+                      </span>
+                    </Image.PreviewGroup>
+                  ) : (
+                    <Image
+                      src={displayUrl}
+                      alt={imageName}
+                      width={50}
+                      height={50}
+                      className="object-cover rounded"
+                      preview={{ src: displayUrl }}
+                    />
+                  )}
+                </div>
               )}
               <span>{imageName}</span>
             </div>

--- a/src/pages/Syllabus/Components/CustomSyllabusList.jsx
+++ b/src/pages/Syllabus/Components/CustomSyllabusList.jsx
@@ -16,15 +16,38 @@ function CustomSyllabusList({ images, loading, statusFilter, setStatusFilter, se
             dataIndex: 'url',
             key: 'url',
             width: 100,
-            render: (url, record) => (
-                <Image
-                    src={url}
-                    alt={record.name}
-                    width={80}
-                    height={80}
-                    className="object-cover rounded"
-                />
-            ),
+            render: (url, record) => {
+                const displayUrl = record.images && record.images.length > 0 ? record.images[0] : url;
+                return (
+                    <div className="relative inline-block group/preview cursor-pointer">
+                        {record.images && record.images.length > 1 ? (
+                            <Image.PreviewGroup>
+                                <Image
+                                    src={displayUrl}
+                                    alt={record.name}
+                                    width={80}
+                                    height={80}
+                                    className="object-cover rounded hover:opacity-90 transition-opacity"
+                                />
+                                {record.images.slice(1).map((imgUrl, idx) => (
+                                    <Image key={idx} src={imgUrl} style={{ display: 'none' }} preview={{ src: imgUrl }} />
+                                ))}
+                                <span className="absolute bottom-0 right-0 bg-black/60 text-white text-[10px] px-1.5 py-0.5 rounded-tl pointer-events-none group-hover/preview:bg-black/80 transition-colors">
+                                    +{record.images.length - 1} view
+                                </span>
+                            </Image.PreviewGroup>
+                        ) : (
+                            <Image
+                                src={displayUrl}
+                                alt={record.name}
+                                width={80}
+                                height={80}
+                                className="object-cover rounded hover:opacity-90 transition-opacity"
+                            />
+                        )}
+                    </div>
+                );
+            },
         },
         {
             title: 'Name',
@@ -40,12 +63,10 @@ function CustomSyllabusList({ images, loading, statusFilter, setStatusFilter, se
                 title: 'Sessions',
                 dataIndex: 'sessionCount',
                 key: 'sessionCount',
-                render: (sessionCount, record) => {
-                    const totalSessions = record.sessionsRequired || 10;
+                render: (sessionCount) => {
                     return (
                         <span className="text-sm">
                             <span className="font-semibold">{sessionCount}</span>
-                            {/* <span className="text-gray-500">/{totalSessions}</span> */}
                         </span>
                     );
                 },

--- a/src/pages/SyllabusGallery/components/SyllabusGalleryForm.jsx
+++ b/src/pages/SyllabusGallery/components/SyllabusGalleryForm.jsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { Button, Form, Input, message, Modal, Upload, Image } from 'antd'
+import { Button, Form, Input, Select, message, Modal, Upload, Image } from 'antd'
 import { PlusOutlined, EditOutlined, InboxOutlined, DeleteOutlined } from '@ant-design/icons'
 import syllabusGalleryService from '@services/SyllabusGalleryService'
+import courseService from '@services/Course'
 import s3Service from '@services/S3Service'
 
 const { Dragger } = Upload
@@ -32,14 +33,48 @@ function SyllabusGalleryForm({ isCreate = true, item = null, onSuccess }) {
     const [loading, setLoading] = useState(false)
     const [form] = Form.useForm()
 
-    // For the upload preview
-    const [previewUrl, setPreviewUrl] = useState(null)
-    const [pendingFile, setPendingFile] = useState(null) // { file, dataUrl }
+    const [courses, setCourses] = useState([])
+
+    // Batch upload state for new files (both Create & Edit mode)
+    const [pendingFiles, setPendingFiles] = useState([]) // Array of { uid, file, dataUrl }
+
+    // Existing images (for Edit mode)
+    const [existingImages, setExistingImages] = useState([])
+
+    useEffect(() => {
+        if (isModalOpen) {
+            fetchCourses()
+        }
+    }, [isModalOpen])
+
+    const fetchCourses = async () => {
+        try {
+            const data = await courseService.getCourses({}, 0, 1000)
+            if (data && data.courses) {
+                setCourses(data.courses)
+            } else if (Array.isArray(data)) {
+                setCourses(data)
+            }
+        } catch (error) {
+            console.error("Failed to fetch courses:", error)
+        }
+    }
 
     const showModal = () => {
         if (item) {
-            form.setFieldsValue({ name: item.name, url: item.url })
-            setPreviewUrl(item.url)
+            form.setFieldsValue({
+                name: item.name,
+                url: item.url,
+                course: typeof item.course === 'object' ? item.course?._id : item.course
+            })
+            // If item has images array, use that. Otherwise fallback to single url if present.
+            if (item.images && item.images.length > 0) {
+                setExistingImages([...item.images])
+            } else if (item.url) {
+                setExistingImages([item.url])
+            } else {
+                setExistingImages([])
+            }
         }
         setIsModalOpen(true)
     }
@@ -47,22 +82,35 @@ function SyllabusGalleryForm({ isCreate = true, item = null, onSuccess }) {
     const handleCancel = () => {
         setIsModalOpen(false)
         form.resetFields()
-        setPreviewUrl(null)
-        setPendingFile(null)
+        setPendingFiles([])
+        setExistingImages([])
+    }
+
+    const handleRemovePendingFile = (uid) => {
+        setPendingFiles(prev => prev.filter(f => f.uid !== uid))
+    }
+
+    const handleRemoveExistingImage = (urlToRemove) => {
+        setExistingImages(prev => prev.filter(url => url !== urlToRemove))
     }
 
     // Intercept file selection — don't auto-upload, just preview
     const beforeUpload = async (file) => {
         const isImage = file.type.startsWith('image/')
         if (!isImage) {
-            message.error('Only image files are allowed')
+            message.error('Only image files are allowed: ' + file.name)
             return Upload.LIST_IGNORE
         }
-        const dataUrl = await readFileAsDataUrl(file)
-        setPreviewUrl(dataUrl)
-        setPendingFile({ file, dataUrl })
 
-        // Auto-fill name from filename if empty
+        const dataUrl = await readFileAsDataUrl(file)
+
+        setPendingFiles(prev => [...prev, {
+            uid: file.uid || Date.now() + Math.random().toString(),
+            file,
+            dataUrl
+        }])
+
+        // Auto-fill name from first filename if empty
         const currentName = form.getFieldValue('name')
         if (!currentName) {
             const ext = file.name.lastIndexOf('.')
@@ -73,46 +121,91 @@ function SyllabusGalleryForm({ isCreate = true, item = null, onSuccess }) {
         return false // prevent ant design auto-upload
     }
 
+    const uploadFileToS3 = async (file, dataUrl) => {
+        const ext = file.name.lastIndexOf('.')
+        const baseName = ext !== -1 ? file.name.slice(0, ext) : file.name
+        const slug = slugify(baseName)
+        const ts = Date.now()
+        const fileName = `${slug}_${ts}${ext !== -1 ? file.name.slice(ext) : ''}`
+
+        const result = await s3Service.uploadFiles({
+            files: [{
+                fileName,
+                fileType: file.type,
+                data: dataUrl,
+                path: 'uploads/syllabus-gallery',
+            }]
+        })
+
+        if (!result?.[0]) throw new Error('Upload failed for ' + file.name)
+        return result[0]
+    }
+
     const handleSubmit = async (values) => {
         setLoading(true)
         try {
-            let url = values.url
-
-            // If a new file was selected, upload it first
-            if (pendingFile) {
-                const { file, dataUrl } = pendingFile
-                const ext = file.name.lastIndexOf('.')
-                const baseName = ext !== -1 ? file.name.slice(0, ext) : file.name
-                const slug = slugify(baseName)
-                const ts = Date.now()
-                const fileName = `${slug}_${ts}${ext !== -1 ? file.name.slice(ext) : ''}`
-
-                const result = await s3Service.uploadFiles({
-                    files: [{
-                        fileName,
-                        fileType: file.type,
-                        data: dataUrl,
-                        path: 'uploads/syllabus-gallery',
-                    }]
-                })
-
-                if (!result?.[0]) throw new Error('Upload failed')
-                url = result[0]
+            // Upload all new pending files
+            let uploadedUrls = []
+            if (pendingFiles.length > 0) {
+                const uploadPromises = pendingFiles.map(pf => uploadFileToS3(pf.file, pf.dataUrl))
+                uploadedUrls = await Promise.all(uploadPromises)
             }
 
-            const payload = { name: values.name, url }
+            // Combine existing images that weren't deleted + newly uploaded files
+            const finalImages = [...existingImages, ...uploadedUrls]
 
             if (isCreate) {
+                if (finalImages.length === 0 && !values.url) {
+                    message.error('Please upload at least one image or provide a URL')
+                    setLoading(false)
+                    return
+                }
+
+                const payload = {
+                    name: values.name,
+                }
+
+                if (finalImages.length > 0) {
+                    payload.images = finalImages;
+                } else if (values.url) {
+                    payload.url = values.url;
+                }
+
+                if (values.course) {
+                    payload.course = values.course;
+                }
+
                 await syllabusGalleryService.createSyllabusGalleryImage(payload)
-                message.success('Gallery image added successfully')
+                message.success(`Gallery content added successfully`)
+
             } else {
+                // Edit Mode Submission
+                const payload = {
+                    name: values.name,
+                    course: values.course || null,
+                }
+
+                // If the user deleted all images but provided a fallback url
+                if (finalImages.length === 0) {
+                    if (!values.url) {
+                        message.error('Please provide at least one image or URL')
+                        setLoading(false)
+                        return
+                    }
+                    payload.url = values.url;
+                    payload.images = []; // Explicitly clear images if they typed a URL
+                } else {
+                    payload.images = finalImages;
+                    // Optional: could clear payload.url since it's now a set, but backend should handle
+                }
+
                 await syllabusGalleryService.updateSyllabusGalleryImage(item._id, payload)
-                message.success('Gallery image updated successfully')
+                message.success('Gallery updated successfully')
             }
 
             form.resetFields()
-            setPreviewUrl(null)
-            setPendingFile(null)
+            setPendingFiles([])
+            setExistingImages([])
             setIsModalOpen(false)
             onSuccess?.()
         } catch (error) {
@@ -126,7 +219,7 @@ function SyllabusGalleryForm({ isCreate = true, item = null, onSuccess }) {
         <>
             {isCreate ? (
                 <Button type="primary" icon={<PlusOutlined />} onClick={showModal} size="large">
-                    Add Gallery Image
+                    Add Gallery Set
                 </Button>
             ) : (
                 <Button type="default" icon={<EditOutlined />} onClick={showModal} size="small">
@@ -135,90 +228,154 @@ function SyllabusGalleryForm({ isCreate = true, item = null, onSuccess }) {
             )}
 
             <Modal
-                title={isCreate ? 'Add Gallery Image' : 'Edit Gallery Image'}
+                title={isCreate ? 'Add Gallery Image Set' : 'Edit Gallery Item'}
                 open={isModalOpen}
                 onCancel={handleCancel}
                 footer={null}
                 destroyOnClose
+                width={600}
             >
                 <Form form={form} layout="vertical" onFinish={handleSubmit} className="mt-4">
-                    {/* Image upload / preview */}
-                    <Form.Item label="Image">
-                        {previewUrl ? (
-                            <div className="relative inline-block">
-                                <Image
-                                    src={previewUrl}
-                                    alt="preview"
-                                    height={160}
-                                    style={{ objectFit: 'cover', borderRadius: 8 }}
-                                />
-                                <Button
-                                    size="small"
-                                    danger
-                                    icon={<DeleteOutlined />}
-                                    style={{ position: 'absolute', top: 4, right: 4 }}
-                                    onClick={() => {
-                                        setPreviewUrl(null)
-                                        setPendingFile(null)
-                                        form.setFieldValue('url', '')
-                                    }}
-                                />
-                            </div>
-                        ) : (
-                            <Dragger
-                                accept="image/*"
-                                showUploadList={false}
-                                beforeUpload={beforeUpload}
-                                style={{ padding: '8px 0' }}
-                            >
-                                <p className="ant-upload-drag-icon">
-                                    <InboxOutlined />
-                                </p>
-                                <p className="ant-upload-text">Click or drag image to upload</p>
-                                <p className="ant-upload-hint">PNG, JPG, WEBP supported</p>
-                            </Dragger>
-                        )}
-                    </Form.Item>
 
                     <Form.Item
                         label="Name"
                         name="name"
                         rules={[
-                            { required: true, message: 'Please enter image name' },
+                            { required: true, message: 'Please enter a name for the item/set' },
                             { max: 100, message: 'Name must be less than 100 characters' },
                         ]}
                     >
-                        <Input placeholder="e.g., javascript-basics" />
+                        <Input placeholder="e.g., Watercolors Masterclass" />
                     </Form.Item>
 
-                    {/* Hidden url field — populated by upload or kept from existing item */}
+                    <Form.Item
+                        label="Associated Course (Optional)"
+                        name="course"
+                    >
+                        <Select
+                            showSearch
+                            placeholder="Select a course to link"
+                            optionFilterProp="children"
+                            filterOption={(input, option) =>
+                                (option?.children ?? '').toLowerCase().includes(input.toLowerCase())
+                            }
+                            allowClear
+                        >
+                            {courses.map(c => (
+                                <Select.Option key={c._id} value={c._id}>
+                                    {c.course_name}
+                                </Select.Option>
+                            ))}
+                        </Select>
+                    </Form.Item>
+
+                    <Form.Item label="Images (Multiple allowed)">
+                        <Dragger
+                            accept="image/*"
+                            multiple={true}
+                            showUploadList={false}
+                            beforeUpload={beforeUpload}
+                            style={{ padding: '8px 0', marginBottom: 16 }}
+                        >
+                            <p className="ant-upload-drag-icon">
+                                <InboxOutlined />
+                            </p>
+                            <p className="ant-upload-text">Click or drag images to upload</p>
+                            <p className="ant-upload-hint">Upload one or multiple images as a Set.</p>
+                        </Dragger>
+
+                        {/* Existing Images Preview (Edit mode) */}
+                        {existingImages.length > 0 && (
+                            <div className="mb-4">
+                                <p className="text-sm text-gray-500 mb-2">Existing Images:</p>
+                                <div className="flex flex-wrap gap-3 max-h-[200px] overflow-y-auto">
+                                    {existingImages.map((url, idx) => (
+                                        <div key={`existing-${idx}`} className="relative group rounded border border-gray-200 overflow-hidden" style={{ width: 100, height: 100 }}>
+                                            <Image
+                                                src={url}
+                                                alt="existing"
+                                                width={100}
+                                                height={100}
+                                                style={{ objectFit: 'cover' }}
+                                                preview={false}
+                                            />
+                                            <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                                                <Button
+                                                    danger
+                                                    type="primary"
+                                                    shape="circle"
+                                                    icon={<DeleteOutlined />}
+                                                    onClick={() => handleRemoveExistingImage(url)}
+                                                    size="small"
+                                                />
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+
+                        {/* New Uploads Preview */}
+                        {pendingFiles.length > 0 && (
+                            <div>
+                                <p className="text-sm flex-none text-gray-500 mb-2">New Uploads:</p>
+                                <div className="flex flex-wrap gap-3 max-h-[200px] overflow-y-auto">
+                                    {pendingFiles.map((pf) => (
+                                        <div key={pf.uid} className="relative group rounded border border-gray-200 overflow-hidden" style={{ width: 100, height: 100 }}>
+                                            <Image
+                                                src={pf.dataUrl}
+                                                alt="preview"
+                                                width={100}
+                                                height={100}
+                                                style={{ objectFit: 'cover' }}
+                                                preview={false}
+                                            />
+                                            <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                                                <Button
+                                                    danger
+                                                    type="primary"
+                                                    shape="circle"
+                                                    icon={<DeleteOutlined />}
+                                                    onClick={() => handleRemovePendingFile(pf.uid)}
+                                                    size="small"
+                                                />
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+                    </Form.Item>
+
+                    {/* Hidden url field used for form submission if it's set programmatically. */}
                     <Form.Item name="url" hidden>
                         <Input />
                     </Form.Item>
 
-                    {/* Fallback: allow pasting a URL if no file picked */}
-                    {!pendingFile && !previewUrl && (
+                    {/* For single fallback item loading */}
+                    {(existingImages.length === 0 && pendingFiles.length === 0) && (
                         <Form.Item
                             label="Or paste an image URL"
                             name="url"
                             rules={[
-                                { required: true, message: 'Upload an image or enter a URL' },
+                                { required: existingImages.length === 0 && pendingFiles.length === 0, message: 'Upload an image or enter a URL' },
                                 { type: 'url', message: 'Please enter a valid URL' },
                             ]}
                         >
-                            <Input placeholder="https://example.com/image.jpg" />
+                            <Input
+                                placeholder="https://example.com/image.jpg"
+                            />
                         </Form.Item>
                     )}
 
-                    <Form.Item className="mb-0 flex justify-end gap-2">
+                    <Form.Item className="flex justify-end gap-2 mb-0 mt-4">
                         <Button onClick={handleCancel}>Cancel</Button>
                         <Button
                             type="primary"
                             htmlType="submit"
                             loading={loading}
-                            disabled={!pendingFile && !previewUrl && !form.getFieldValue('url')}
                         >
-                            {isCreate ? 'Add' : 'Update'}
+                            {isCreate ? 'Add Set' : 'Update Section'}
                         </Button>
                     </Form.Item>
                 </Form>
@@ -233,6 +390,8 @@ SyllabusGalleryForm.propTypes = {
         _id: PropTypes.string,
         name: PropTypes.string,
         url: PropTypes.string,
+        course: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+        images: PropTypes.arrayOf(PropTypes.string),
     }),
     onSuccess: PropTypes.func,
 }

--- a/src/pages/SyllabusGallery/components/SyllabusGalleryItem.jsx
+++ b/src/pages/SyllabusGallery/components/SyllabusGalleryItem.jsx
@@ -1,28 +1,69 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Image } from 'antd'
+import { Image, Carousel, Tag } from 'antd'
 
 function SyllabusGalleryItem({ item, onClick }) {
+    const hasImagesArray = item.images && item.images.length > 0;
+    const isCarousel = hasImagesArray && item.images.length > 1;
+
+    // We can show the first image as fallback if not carousel
+    const displayUrl = hasImagesArray ? item.images[0] : item.url;
+
     return (
         <div
             className="relative group cursor-pointer overflow-hidden rounded-lg shadow-md hover:shadow-xl transition-all duration-300"
             onClick={onClick}
         >
-            <Image
-                src={item.url}
-                alt={item.name}
-                preview={false}
-                className="w-full h-auto object-cover"
-                fallback="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMIAAADDCAYAAADQvc6UAAABRWlDQ1BJQ0MgUHJvZmlsZQAAKJFjYGASSSwoyGFhYGDIzSspCnJ3UoiIjFJgf8LAwSDCIMogwMCcmFxc4BgQ4ANUwgCjUcG3awyMIPqyLsis7PPOq3QdDFcvjV3jOD1boQVTPQrgSkktTgbSf4A4LbmgqISBgTEFyFYuLykAsTuAbJEioKOA7DkgdjqEvQHEToKwj4DVhAQ5A9k3gGyB5IxEoBmML4BsnSQk8XQkNtReEOBxcfXxUQg1Mjc0dyHgXNJBSWpFCYh2zi+oLMpMzyhRcASGUqqCZ16yno6CkYGRAQMDKMwhqj/fAIcloxgHQqxAjIHBEugw5sUIsSQpBobtQPdLciLEVJYzMPBHMDBsayhILEqEO4DxG0txmrERhM29nYGBddr//5/DGRjYNRkY/l7////39v///y4Dmn+LgeHANwDrkl1AuO+pmgAAADhlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAAqACAAQAAAABAAAAwqADAAQAAAABAAAAwwAAAAD9b/HnAAAHlklEQVR4Ae3dP3PTWBSGcbGzM6GCKqlIBRV0dHRJFarQ0eUT8LH4BnRU0NHR0UEFVdIlFRV7TzRksomPY8uykTk/zewQfKw/9znv4yvJynLv4uLiV2dBoDiBf4qP3/ARuCRABEFAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghgg0Aj8i0JO4OzsrPv69Wv+hi2qPHr0qNvf39+iI97soRIh4f3z58/u7du3SXX7Xt7Z2enevHmzfQe+oSN2apSAPj09TSrb+XKI/f379+08+A0cNRE2ANkupk+ACNPvkSPcAAEibACyXUyfABGm3yNHuAECRNgAZLuYPgEirKlHu7u7XdyytGwHAd8jjNyng4OD7vnz51dbPT8/7z58+NB9+/bt6jU/TI+AGWHEnrx48eJ/EsSmHzx40L18+fLyzxF3ZVMjEyDCiEDjMYZZS5wiPXnyZFbJaxMhQIQRGzHvWR7XCyOCXsOmiDAi1HmPMMQjDpbpEiDCiL358eNHurW/5SnWdIBbXiDCiA38/Pnzrce2YyZ4//59F3ePLNMl4PbpiL2J0L979+7yDtHDhw8vtzzvdGnEXdvUigSIsCLAWavHp/+qM0BcXMd/q25n1vF57TYBp0a3mUzilePj4+7k5KSLb6gt6ydAhPUzXnoPR0dHl79WGTNCfBnn1uvSCJdegQhLI1vvCk+fPu2ePXt2tZOYEV6/fn31dz+shwAR1sP1cqvLntbEN9MxA9xcYjsxS1jWR4AIa2Ibzx0tc44fYX/16lV6NDFLXH+YL32jwiACRBiEbf5KcXoTIsQSpzXx4N28Ja4BQoK7rgXiydbHjx/P25TaQAJEGAguWy0+2Q8PD6/Ki4R8EVl+bzBOnZY95fq9rj9zAkTI2SxdidBHqG9+skdw43borCXO/ZcJdraPWdv22uIEiLA4q7nvvCug8WTqzQveOH26fodo7g6uFe/a17W3+nFBAkRYENRdb1vkkz1CH9cPsVy/jrhr27PqMYvENYNlHAIesRiBYwRy0V+8iXP8+/fvX11Mr7L7ECueb/r48eMqm7FuI2BGWDEG8cm+7G3NEOfmdcTQw4h9/55lhm7DekRYKQPZF2ArbXTAyu4kDYB2YxUzwg0gi/41ztHnfQG26HbGel/crVrm7tNY+/1btkOEAZ2M05r4FB7r9GbAIdxaZYrHdOsgJ/wCEQY0J74TmOKnbxxT9n3FgGGWWsVdowHtjt9Nnvf7yQM2aZU/TIAIAxrw6dOnAWtZZcoEnBpNuTuObWMEiLAx1HY0ZQJEmHJ3HNvGCBBhY6jtaMoEiJB0Z29vL6ls58vxPcO8/zfrdo5qvKO+d3Fx8Wu8zf1dW4p/cPzLly/dtv9Ts/EbcvGAHhHyfBIhZ6NSiIBTo0LNNtScABFyNiqFCBChULMNNSdAhJyNSiECRCjUbEPNCRAhZ6NSiAARCjXbUHMCRMjZqBQiQIRCzTbUnAARcjYqhQgQoVCzDTUnQIScjUohAkQo1GxDzQkQIWejUogAEQo121BzAkTI2agUIkCEQs021JwAEXI2KoUIEKFQsw01J0CEnI1KIQJEKNRsQ80JECFno1KIABEKNdtQcwJEyNmoFCJAhELNNtScABFyNiqFCBChULMNNSdAhJyNSiECRCjUbEPNCRAhZ6NSiAARCjXbUHMCRMjZqBQiQIRCzTbUnAARcjYqhQgQoVCzDTUnQIScjUohAkQo1GxDzQkQIWejUogAEQo121BzAkTI2agUIkCEQs021JwAEXI2KoUIEKFQsw01J0CEnI1KIQJEKNRsQ80JECFno1KIABEKNdtQcwJEyNmoFCJAhELNNtScABFyNiqFCBChULMNNSdAhJyNSiECRCjUbEPNCRAhZ6NSiAARCjXbUHMCRMjZqBQiQIRCzTbUnAARcjYqhQgQoVCzDTUnQIScjUohAkQo1GxDzQkQIWejUogAEQo121BzAkTI2agUIkCEQs021JwAEXI2KoUIEKFQsw01J0CEnI1KIQJE+H/27oB5UqtGAAAAAElFTkSuQmCC"
-            />
+            {isCarousel ? (
+                <div onClick={(e) => {
+                    // Prevent clicks on carousel arrows/dots from triggering the root onClick
+                    if (e.target.closest('.slick-arrow') || e.target.closest('.slick-dots')) {
+                        e.stopPropagation();
+                    }
+                }} className="bg-gray-100">
+                    <Carousel
+                        effect="fade"
+                        autoplay={false}
+                        dots={true}
+                        arrows={false}
+                        className="w-full h-auto"
+                    >
+                        {item.images.map((imgUrl, i) => (
+                            <div key={i}>
+                                <Image
+                                    src={imgUrl}
+                                    alt={`${item.name} - part ${i + 1}`}
+                                    preview={false}
+                                    className="w-full h-auto object-cover"
+                                />
+                            </div>
+                        ))}
+                    </Carousel>
+                </div>
+            ) : (
+                <Image
+                    src={displayUrl}
+                    alt={item.name}
+                    preview={false}
+                    className="w-full h-auto object-cover bg-gray-100"
+                />
+            )}
 
-            {/* Overlay with name */}
-            <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4">
-                <h3 className="text-white font-semibold text-sm truncate">{item.name}</h3>
+            {/* Overlay with name and optional course badge */}
+            <div className={`absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4 flex flex-col items-start pointer-events-none`}>
+                <h3 className="text-white font-semibold text-sm truncate w-full">{item.name}</h3>
+                {item.course && item.course.course_name && (
+                    <Tag color="cyan" className="mt-1 mb-0 border-none shadow-sm">{item.course.course_name}</Tag>
+                )}
+                {isCarousel && (
+                    <div className="mt-1">
+                        <Tag color="default" className="m-0 border-none bg-black/50 text-white">{item.images.length} images</Tag>
+                    </div>
+                )}
             </div>
 
-            {/* Hover overlay */}
-            <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-all duration-300" />
+            {/* Hover overlay - disabled pointer events so carousel controls still work */}
+            <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-all duration-300 pointer-events-none" />
         </div>
     )
 }
@@ -31,7 +72,9 @@ SyllabusGalleryItem.propTypes = {
     item: PropTypes.shape({
         _id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
-        url: PropTypes.string.isRequired,
+        url: PropTypes.string,
+        images: PropTypes.arrayOf(PropTypes.string),
+        course: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     }).isRequired,
     onClick: PropTypes.func.isRequired,
 }

--- a/src/services/SyllabusGalleryService.js
+++ b/src/services/SyllabusGalleryService.js
@@ -6,9 +6,14 @@ class SyllabusGalleryService {
      * Get all syllabus gallery images
      * @returns {Promise<Array>} Array of gallery images
      */
-    async getSyllabusGalleryImages({ page = 1, limit = 20, search = "" } = {}) {
+    async getSyllabusGalleryImages({ page = 1, limit = 20, search = "", course = "", type = "" } = {}) {
         try {
-            const params = new URLSearchParams({ page, limit, ...(search && { search }) });
+            const paramsParams = { page, limit };
+            if (search) paramsParams.search = search;
+            if (course && course !== 'all') paramsParams.course = course;
+            if (type && type !== 'all') paramsParams.type = type;
+
+            const params = new URLSearchParams(paramsParams);
             const response = await get(`/v2/syllabusGallery?${params}`);
             if (!response || !response.data)
                 throw new Error("An error occurred. Please try again");
@@ -46,8 +51,11 @@ class SyllabusGalleryService {
      */
     async createSyllabusGalleryImage(data) {
         try {
-            if (!data.name || !data.url) {
-                throw new Error("Please fill all required fields");
+            if (!data.name) {
+                throw new Error("Please provide a name");
+            }
+            if (!data.url && (!data.images || !Array.isArray(data.images) || data.images.length === 0)) {
+                throw new Error("Please provide an image or images array");
             }
             const response = await post("/v2/syllabusGallery", data);
             if (!response || !response.data)
@@ -68,8 +76,11 @@ class SyllabusGalleryService {
     async updateSyllabusGalleryImage(id, data) {
         try {
             if (!id) throw new Error("Invalid image ID");
-            if (!data.name || !data.url) {
-                throw new Error("Please fill all required fields");
+            if (!data.name) {
+                throw new Error("Please provide a name");
+            }
+            if (!data.url && (!data.images || !Array.isArray(data.images) || data.images.length === 0)) {
+                throw new Error("Please provide an image or images array");
             }
             const response = await put(`/v2/syllabusGallery/${id}`, data);
             if (!response || !response.data)


### PR DESCRIPTION
Add first-class support for multi-image sets across activities, students, syllabus and gallery components. Key changes:

- ActivityItem: added Image component preview group, download button (supports downloading multiple images), and accepts images array. Added Image import.
- ActivityList/SessionStatusTable/CustomSyllabusList: updated renderers to prefer record.images[0] and show preview groups + badges when multiple images exist.
- SyllabusGalleryForm: refactored to support uploading multiple images (pendingFiles), existing image management (remove), batch S3 uploads, optional course association, and improved form validation/UX for image sets.
- SyllabusGalleryItem/SyllabusGalleryList: show carousels for image sets, badges for counts, filters (course & type), course fetching, improved modal detail view with carousel preview and print styling tweaks, and safer click handling.
- AssignCustomSyllabusModal: send images array when assigning if present, show counts and previews, and added PropTypes.
- SyllabusGalleryService usage updated where needed to send payload.images or fallback url to remain backward compatible.
- Misc: added PropTypes, course service calls, UI polish (badges, hover overlays), improved loading states and debouncing for fetches.

Overall this enables image "sets" (multiple urls per gallery item), better previews, downloads, and course-linked filtering while preserving single-url fallbacks.